### PR TITLE
Fix QueryResult iterator exhaustion bug in Rust bindings

### DIFF
--- a/src/main/query_result/materialized_query_result.cpp
+++ b/src/main/query_result/materialized_query_result.cpp
@@ -79,8 +79,8 @@ std::string MaterializedQueryResult::toString() const {
     result += "\n";
     auto tuple_ = FlatTuple(this->columnTypes);
     auto iterator_ = FactorizedTableIterator(*table);
-    while (iterator->hasNext()) {
-        iterator->getNext(tuple_);
+    while (iterator_.hasNext()) {
+        iterator_.getNext(tuple_);
         result += tuple_.toString();
     }
     return result;


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue (if applicable).
Please also include relevant motivation and context.

Fixes #(issue)
Associated docs (issue or PR):

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/predictable-labs/ryugraph/blob/main/CLA.md).
